### PR TITLE
Fix writeFile api docu typo

### DIFF
--- a/docs/site_development/zeroframe_api_reference.md
+++ b/docs/site_development/zeroframe_api_reference.md
@@ -472,10 +472,10 @@ Parameter            | Description
 Write file content
 
 
-Parameter        | Description
-             --- | ---
-**inner_path**   | Inner path of the file you want to write
-**content**      | Content you want to write to file (base64 encoded)
+Parameter          | Description
+               --- | ---
+**inner_path**     | Inner path of the file you want to write
+**content_base64** | Content you want to write to file (base64 encoded)
 
 **Return**: "ok" on success else the error message
 


### PR DESCRIPTION
it is not "content" but "content_base64".
If send "content" parameters in writeFile cmd, there will be a parameter type error.