### PR TITLE
Add coding conventions to help_zeronet category

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,5 +30,6 @@ pages:
   - "Certificate authority": "site_development/cert_authority.md"
 - "Help ZeroNet development":
   - "Contributing to ZeroNet": "help_zeronet/contributing.md"
+  - "Coding Conventions": "help_zeronet/coding_conventions.md"
   - "Network protocol": "help_zeronet/network_protocol.md"
   - "Donation": "help_zeronet/donate.md"


### PR DESCRIPTION
Not sure if this was removed on purpose or not, but mkdocs complains when building if this file is just sitting around without being used.

Thus we should either include it in the site or remove it. Assuming we want to do the former, I've made this PR to re-add it to the site.

I also don't mind fixing it up a bit if we do want to include it :)