### PR TITLE
Fixes to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,9 +19,9 @@ pages:
 - Introduction: "index.md"
 - Frequently asked questions: "faq.md"
 - Start using ZeroNet:
-  - "Installing": using_zeronet/installing.md
-  - "Sample sites": using_zeronet/sample_sites.md
-  - "Create new site": using_zeronet/create_new_site.md
+  - "Installing": "using_zeronet/installing.md"
+  - "Sample sites": "using_zeronet/sample_sites.md"
+  - "Create new site": "using_zeronet/create_new_site.md"
 - "Site Development":
   - "Getting Started": "site_development/getting_started.md"
   - "ZeroFrame API reference": "site_development/zeroframe_api_reference.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ theme:
   logo: 'logo/zeronet_logo.svg'
   name: 'material'
 
-pages:
+nav:
 - Introduction: "index.md"
 - Frequently asked questions: "faq.md"
 - Start using ZeroNet:


### PR DESCRIPTION
* Add missing quotations (just for consistency's sake)
* Change deprecated "pages" key to "nav". Squashes a mkdocs warning.