### PR TITLE
Make it so site titles do not change when clicked in sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,17 +19,17 @@ nav:
 - Introduction: "index.md"
 - Frequently asked questions: "faq.md"
 - Start using ZeroNet:
-  - "Installing": "using_zeronet/installing.md"
-  - "Sample sites": "using_zeronet/sample_sites.md"
-  - "Create new site": "using_zeronet/create_new_site.md"
-- "Site Development":
-  - "Getting Started": "site_development/getting_started.md"
-  - "ZeroFrame API reference": "site_development/zeroframe_api_reference.md"
-  - "Structure of content.json": "site_development/content_json.md"
-  - "Structure of dbschema.json": "site_development/dbschema_json.md"
-  - "Certificate authority": "site_development/cert_authority.md"
-- "Help ZeroNet development":
-  - "Contributing to ZeroNet": "help_zeronet/contributing.md"
-  - "Coding Conventions": "help_zeronet/coding_conventions.md"
-  - "Network protocol": "help_zeronet/network_protocol.md"
-  - "Donation": "help_zeronet/donate.md"
+  - "using_zeronet/installing.md"
+  - "using_zeronet/sample_sites.md"
+  - "using_zeronet/create_new_site.md"
+- Site Development:
+  - "site_development/getting_started.md"
+  - "site_development/zeroframe_api_reference.md"
+  - "site_development/content_json.md"
+  - "site_development/dbschema_json.md"
+  - "site_development/cert_authority.md"
+- Help ZeroNet development:
+  - "help_zeronet/contributing.md"
+  - "help_zeronet/coding_conventions.md"
+  - "help_zeronet/network_protocol.md"
+  - "help_zeronet/donate.md"


### PR DESCRIPTION
Likely a bug, but either way if we gave doc pages titles in the config, they would change and re-arrange as the user selected them. Removing them from the config prompts mkdocs to just take them from the doc itself, which means they don't get out of sync, and we won't need to set the title manually in the config anymore either!