### PR TITLE
Fix up Getting Started page

### DIFF
--- a/docs/site_development/getting_started.md
+++ b/docs/site_development/getting_started.md
@@ -1,17 +1,21 @@
-# Overview
+# Getting Started
 
-ZeroNet allows you to publish static and dynamic sites.
+ZeroNet allows you to publish static and dynamic websites on a distributed web platform.
 
-Although ZeroNet can't run scripting languages like PHP or Ruby, you can create dynamic sites using ZeroNet's API (called ZeroFrame), JavaScript (or CoffeeScript) and the built-in SQL database.
+In ZeroNet there is no concept of servers. Thus, server-side languages like PHP or Ruby are not needed. Instead, one can create dynamic content using ZeroNet's API (called ZeroFrame), JavaScript (or CoffeeScript) and the SQL database provided to all websites.
 
-## ZeroChat tutorial
+## Tutorials
 
-In this tutorial we going to build a P2P, decentralized, server and backend-less chat site in less then 100 lines of code.
+### ZeroChat tutorial
+
+In this tutorial we are going to build a P2P, decentralized, server-less chat site in less then 100 lines of code.
 
 * [Read on ZeroBlog](http://127.0.0.1:43110/Blog.ZeroNetwork.bit/?Post:99:ZeroChat+tutorial)
 * [Read on Medium.com](https://decentralize.today/decentralized-p2p-chat-in-100-lines-of-code-d6e496034cd4)
 
-## ZeroNet Debug mode
+## Useful Information
+
+### ZeroNet Debug mode
 
 ZeroNet comes with a `--debug` flag that will make site development easier.
 
@@ -22,7 +26,7 @@ If you are using compiled/bundle version of ZeroNet:
 * On Linux: `./ZeroNet.sh --debug`
 * On Mac: `./ZeroNet.app/Contents/MacOS/ZeroNet --debug`
 
-### Debug mode features:
+#### Debug mode features:
 
 - Automatic CoffeeScript -> JavaScript conversion (All examples used in this documentation and sample sites are written in [CoffeeScript](http://coffeescript.org/))
 - Debug messages will appear in the console
@@ -30,8 +34,28 @@ If you are using compiled/bundle version of ZeroNet:
 - `http://127.0.0.1:43110/Debug` Traceback and interactive Python console at the last error position (using the wonderful Werkzeug debugger - Requires [Werkzeug](http://werkzeug.pocoo.org/))
 - `http://127.0.0.1:43110/Console` Spawns an interactive Python console (Requires [Werkzeug](http://werkzeug.pocoo.org/))
 
+### Disable HTTP Browser Caching
+
+In addition to Debug Mode, disabling HTTP Caching in the browser is an essential part of ZeroNet site development. Modern web browsers attempt to cache web content whenever they can. As all ZeroNet sites run in an iframe, web browsers cannot detect when a ZeroNet site's content changes, and thus site changes are often not reflected if HTTP Caching is enabled.
+
+To disable, open your browser's devtools, navigate to the devtools settings and check the option along the lines of 'Disable HTTP Cache (when toolbox is open)'. As the setting suggests, make sure to keep devtools open when testing new changes to your site!
+
 ### Extra features (works only for sites that you own)
 
  - Merged CSS files: All CSS files inside the site folder will be merged into one file called `all.css`. You can choose to include only this file to your site. If you want to keep the other CSS files to make the development easier, you can add them to the ignore key of your `content.json`. This way, they won't be published with your site. (eg: add to your `content.json` `"ignore": "(js|css)/(?!all.(js|css))"` this will ignore all CSS and JS files except `all.js` and `all.css`)
  - Merged JS files: All JS files inside the site folder will be merged into one file called `all.js`. If a CoffeeScript compiler is present (bundled for Windows) it will convert `.coffee` to `.js`.
  - Order in which files are merged into all.css/all.js: Files inside subdirectories of the css/js folder comes first; Files in the css/js folder will be merged according to file name ordering (01_a.css, 02_a.css, etc)
+
+## Need Help?
+
+ZeroNet has a growing community of developers who hang out in various spaces. If you would like to ask for help, advice or just want to hang out, feel free to connect in to the following services:
+
+### Forums
+
+* [ZeroExchange](http://127.0.0.1:43110/zeroexchange.bit/), a p2p StackOverflow clone
+* [ZeroTalk](http://127.0.0.1:43110/Talk.ZeroNetwork.bit/), a p2p Reddit-like forum
+
+### Chat
+
+* [#zeronet-dev:matrix.org](https://riot.im/app/#/room/#zeronet-dev:matrix.org) on Matrix
+* IRC at #zeronet on Freenode

--- a/docs/site_development/zeroframe_api_reference.md
+++ b/docs/site_development/zeroframe_api_reference.md
@@ -1,10 +1,14 @@
 # ZeroFrame API Reference
 
+## The ZeroFrame API
 
+ZeroFrame is an API that allows ZeroNet websites to interact with the ZeroNet daemon. It allows sites to save/retrieve files, publish changes and many other things. A copy of the library is included at `js/ZeroFrame.js` whenever a new site is created.
+
+The library can be imported like any other JavaScript file, or site developers also have the option of [importing through NPM](ZeroFrame API Page, ##Import?). Please see the [ZeroFrame API Reference]() for API details.
 
 ## Wrapper
 
-_These commands handled by wrapper frame and does not sent to UiServer using websocket_
+_These commands are handled by the wrapper frame and are thus not sent to the UiServer using websocket._
 
 
 ### wrapperConfirm _message, [button_caption]_


### PR DESCRIPTION
Fixes up some sentences, moves the ZeroFrame stuff to the ZeroFrame page, and add new sections about Disabling HTTP Caching and where developers can go to ask others for help.

Rendered: https://zerodocs.amorgan.xyz/site_development/getting_started/