### PR TITLE
Fix edit documentation links

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,17 +1,3 @@
-$(function() {
-	//$("[role=contentinfo]").append("<a href='#loadComments' class='loadcomments'>Load comments</a>");
-	setTimeout(loadComments, 3000)
-	$(".rst-current-version").on("click", function() {
-		fixGithubLink($('.injected a:contains(View)'))
-		fixGithubLink($('.injected a:contains(Edit)'))
-	})
-})
-
-function fixGithubLink(elem) {
-	if (elem.length)
-		elem.attr("href", elem.attr("href").replace(/\/home\/docs\/checkouts\/readthedocs.org\/.*?\/latest/, ""))
-}
-
 function loadComments() {
 	$("[role=contentinfo]").append('<div id="disqus_thread"></div>')
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://github.com/HelloZeroNet/ZeroNet
 site_description: Decentralized websites using Bitcoin crypto and the BitTorrent network
 
 repo_url: https://github.com/HelloZeroNet/ZeroNet
+edit_uri: ../Documentation/edit/master/docs/
 
 extra_css: [docs.css]
 extra_javascript: [docs.js]


### PR DESCRIPTION
Now the little edit buttons point to both the correct repository and the edit screen of the correct file.

Try it out: https://zerodocs.amorgan.xyz/