### PR TITLE
Show admin commands on sidebar

### DIFF
--- a/docs/site_development/zeroframe_api_reference.md
+++ b/docs/site_development/zeroframe_api_reference.md
@@ -1243,7 +1243,7 @@ Parameter            | Description
 ---
 
 
-# Admin commands
+## Admin commands
 _(requires ADMIN permission in data/sites.json)_
 
 


### PR DESCRIPTION
Fix the admin commands title depth so that they [show in the sidebar](https://user-images.githubusercontent.com/1342360/46755465-69c5e280-ccc5-11e8-86ba-1fa2817135cd.png).