### PR TITLE
Add permalinks to all titles

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,10 @@ theme:
   name: "readthedocs"
   favicon: "logo/favicon.ico"
 
+markdown_extensions:
+  - toc:
+      permalink: true
+
 nav:
 - Introduction: "index.md"
 - Frequently asked questions: "faq.md"


### PR DESCRIPTION
Also compatible for the readthedocs theme. Allows people to link to a specific portion of the documentation.