### PR TITLE
Redirect old docs to new docs

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -70,6 +70,13 @@ ul { font-size: 16px }
   100% { bottom: 0; }
 }
 
+/* Make notice stretch across the bottom on mobile */
+@media screen and (max-width: 450px) {
+  .notice {
+    width: 100%;
+  }
+}
+
 input, .md-search__input::placeholder, .md-search__input ~ .md-search__icon {
   color: #ecedee;
 }

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -47,6 +47,29 @@ ul { font-size: 16px }
   margin-top: -5px;
 }
 
+/* redirect notice */
+.notice {
+  text-align: center;
+  position: fixed;
+  bottom: -50%;
+  right: 0px;
+  border: 1px solid #ccc;
+  padding: 1em;
+  background-color: #d8d8d8;
+  -webkit-animation: slide 0.5s forwards;
+  -webkit-animation-delay: 4s;
+  animation: slide 1.0s forwards;
+  animation-delay: 2s;
+}
+
+@-webkit-keyframes slide {
+  100% { bottom: 0; }
+}
+
+@keyframes slide {
+  100% { bottom: 0; }
+}
+
 input, .md-search__input::placeholder, .md-search__input ~ .md-search__icon {
   color: #ecedee;
 }

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,11 +1,40 @@
-function loadComments() {
-	$("[role=contentinfo]").append('<div id="disqus_thread"></div>')
+const currentDocsURL = 'https://zeronet.io/docs'
+const oldDocsURL = 'https://zeronet.readthedocs.io'
 
-	var disqus_shortname = 'zeronet';
+// Point user to new documentation URL if necessary
+if (window.location.href.startsWith(oldDocsURL)) {
+    showRedirectNotice()
+}
 
-	(function() {
-	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-	})();
+// addRedirectNotice shows a message about the current docs being outdated
+function showRedirectNotice() {
+    const notice = `
+    <div class="notice">
+        <h4>Hello there!</h4>
+        <p>
+            You're currently reading <strong>outdated</strong> documentation.<br>
+            View the new docs at <a href="#" onclick="redirect()">` + currentDocsURL + `</a>
+        </p>
+    </div>
+    `
+    document.body.innerHTML += notice
+}
+
+// redirect takes the user to the new documentation, and the same page
+// if it exists, otherwise the homepage
+function redirect() {
+    let newDocsURL = currentDocsURL + window.location.pathname.slice('/en/latest'.length);
+    if (pageExists(newDocsURL)) {
+        window.location = newDocsURL;
+    } else {
+        window.location = currentDocsURL;
+    }
+}
+
+// pageExists takes in a URL and checks if it returns a 404
+function pageExists(newDocsURL) {
+    var request = new XMLHttpRequest;
+    request.open('GET', newDocsURL, true);
+    request.send();
+    return (request.status == 200)
 }


### PR DESCRIPTION
Here is some JavaScript to redirect the old docs pages to the new site. A little pop up notice shows if it detects you're on the old site, and offers to take you to the new one.

If the page you're currently on is available on the new site, it will take you directly there, otherwise you'll be taken to the homepage.

I've set up a little demo that you can try [here](https://zerodocs.amorgan.xyz/en/latest/), treating my own site as the old site. CORS [is still required](https://github.com/HelloZeroNet/Documentation/issues/101#issuecomment-431678002) for this to function properly, but as the docs pages are very similar at the moment I've gone ahead and made the check assume the page always exists.