### PR TITLE
Change theme back to material

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ theme:
     primary: "deep purple"
     accent: "deep purple"
   logo: "logo/zeronet_logo.svg"
-  name: "readthedocs"
+  name: "material"
   favicon: "logo/favicon.ico"
 
 markdown_extensions:


### PR DESCRIPTION
Changes the theme in `mkdocs.yml` back to 'material'.

I recommend merging #103 first, updating readthedocs.io for the last time, then merging this PR and using that as the new base for https://zeronet.io/docs