### PR TITLE
Change all internal docs URLs to be relative

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -235,7 +235,7 @@ ZeroNet is built for dynamic, real-time updated websites, but you can serve any 
 
 #### How can I create a new ZeroNet site?
 
-[Follow these instructions.](/using_zeronet/create_new_site/)
+[Follow these instructions.](../using_zeronet/create_new_site/)
 
 ---
 
@@ -253,5 +253,5 @@ ZeroNet is built for dynamic, real-time updated websites, but you can serve any 
   integrity (using the signature), they __download the modified files__ and serve the new content to other peers.
 
 More info:
- [ZeroNet sample sites](/using_zeronet/sample_sites/),
+ [ZeroNet sample sites](../using_zeronet/sample_sites/),
  [Slideshow about how ZeroNet works](https://docs.google.com/presentation/d/1_2qK1IuOKJ51pgBvllZ9Yu7Au2l551t3XBgyTSvilew/pub)

--- a/docs/using_zeronet/create_new_site.md
+++ b/docs/using_zeronet/create_new_site.md
@@ -59,4 +59,4 @@ Site:13DNDk..bhC2 Successfuly published to 3 peers
 * Your site will be accessible from: ```http://localhost:43110/13DNDkMUExRf9Xa9ogwPKqp7zyHFEqbhC2```
 
 
-**Next steps:** [ZeroNet Developer Documentation](/site_development/getting_started/)
+**Next steps:** [ZeroNet Developer Documentation](../../site_development/getting_started/)


### PR DESCRIPTION
Otherwise links like `/using_zeronet/sample_sites` leads to https://zeronet.io/using_zeronet/sample_sites, which of course does not exist.